### PR TITLE
Matching mobs via registry names from config

### DIFF
--- a/src/main/java/xt9/deepmoblearning/DeepConstants.java
+++ b/src/main/java/xt9/deepmoblearning/DeepConstants.java
@@ -197,4 +197,127 @@ public class DeepConstants {
             "deepmoblearning:glitch_heart,5,0"
         };
     }
+
+    public static final class MOBS {
+        public static final String[] CREEPER = {
+                "minecraft:creeper"
+        };
+
+        public static final String[] BLAZE = {
+                "minecraft:blaze"
+        };
+
+        public static final String[] DRAGON = {
+                "minecraft:ender_dragon"
+        };
+
+        public static final String[] ENDERMAN = {
+                "minecraft:enderman"
+        };
+
+        public static final String[] GHAST = {
+                "minecraft:ghast"
+        };
+
+        public static final String[] SKELETON = {
+                "minecraft:stray",
+                "minecraft:skeleton",
+                "twilightforest:skeleton_druid"
+        };
+
+        public static final String[] SLIME = {
+                "minecraft:slime",
+                "minecraft:magma_cube",
+        };
+
+        public static final String[] SPIDER = {
+                "minecraft:spider",
+                "minecraft:cave_spider",
+                "twilightforest:hedge_spider",
+                "twilightforest:king_spider",
+        };
+
+        public static final String[] THERMALELEMENTAL = {
+                "thermalfoundation:blizz",
+                "thermalfoundation:blitz",
+                "thermalfoundation:basalz",
+        };
+
+        public static final String[] TINKERSLIME = {
+                "tconstruct:blueslime"
+        };
+
+        public static final String[] TWILIGHTFOREST = {
+                "twilightforest:naga",
+                "twilightforest:lich_minion",
+                "twilightforest:lich",
+                "twilightforest:death_tome",
+                "twilightforest:swarm_spider",
+        };
+
+        public static final String[] TWILIGHTSWAMP = {
+                "twilightforest:minotaur",
+                "twilightforest:minoshroom",
+                "twilightforest:maze_slime",
+                "twilightforest:fire_beetle",
+                "twilightforest:pinch_beetle",
+                "twilightforest:slime_beetle",
+                "twilightforest:hydra",
+        };
+
+        public static final String[] TWILIGHTDARKWOOD = {
+                "twilightforest:redcap",
+                "twilightforest:blockchain_goblin",
+                "twilightforest:kobold",
+                "twilightforest:goblin_knight_lower",
+                "twilightforest:goblin_knight_upper",
+                "twilightforest:helmet_crab",
+                "twilightforest:knight_phantom",
+                "twilightforest:tower_ghast",
+                "twilightforest:tower_broodling",
+                "twilightforest:tower_golem",
+                "twilightforest:tower_termite",
+                "twilightforest:mini_ghast",
+                "twilightforest:ur_ghast",
+        };
+
+        public static final String[] TWILIGHTGLACIER = {
+                "twilightforest:yeti_alpha",
+                "twilightforest:yeti",
+                "twilightforest:winter_wolf",
+                "twilightforest:penguin",
+                "twilightforest:snow_guardian",
+                "twilightforest:stable_ice_core",
+                "twilightforest:unstable_ice_core",
+                "twilightforest:snow_queen",
+        };
+
+        public static final String[] WITCH = {
+                "minecraft:witch"
+        };
+
+        public static final String[] WITHERSKELETON = {
+                "minecraft:wither_skeleton"
+        };
+
+        public static final String[] WITHER = {
+                "minecraft:wither"
+        };
+
+        public static final String[] ZOMBIE = {
+                "minecraft:husk",
+                "minecraft:zombie",
+                "minecraft:zombie_villager",
+                "minecraft:zombie_pigman",
+        };
+
+        public static final String[] SHULKER = {
+                "minecraft:shulker"
+        };
+
+        public static final String[] GUARDIAN = {
+                "minecraft:elder_guardian",
+                "minecraft:guardian",
+        };
+    }
 }

--- a/src/main/java/xt9/deepmoblearning/client/gui/config/DeepGuiConfig.java
+++ b/src/main/java/xt9/deepmoblearning/client/gui/config/DeepGuiConfig.java
@@ -22,6 +22,7 @@ public class DeepGuiConfig extends GuiConfig {
     public static List<IConfigElement> getConfigElements() {
         List <IConfigElement> elements = new ArrayList<>();
         elements.add(new ConfigElement(Config.dataModel));
+        elements.add(new ConfigElement(Config.dataModelMobs));
         elements.add(new ConfigElement(Config.livingMatterEXP));
         elements.add(new ConfigElement(Config.pristineChance));
         elements.add(new ConfigElement(Config.modelExperience));

--- a/src/main/java/xt9/deepmoblearning/common/config/Config.java
+++ b/src/main/java/xt9/deepmoblearning/common/config/Config.java
@@ -21,6 +21,7 @@ import java.io.File;
 public class Config {
     private static Configuration config = new DMLConfiguration(new File("config/" + DeepConstants.MODID + ".cfg"));
     public static ConfigCategory dataModel = new ConfigCategory("data model simulation costs");
+    public static ConfigCategory dataModelMobs = new ConfigCategory("data model mob");
     public static ConfigCategory pristineChance = new ConfigCategory("pristine matter chance");
     public static ConfigCategory modelExperience = new ConfigCategory("model experience tweaks");
     public static ConfigCategory pristineOutputs = new ConfigCategory("pristine output items");
@@ -41,6 +42,7 @@ public class Config {
     public static void initConfigValues() {
         initLivingMatterEXP();
         initDataModelRFCost();
+        initDataModelMobs();
         initPristineChance();
         initModelExperience();
         initPristineOutputs();
@@ -99,6 +101,40 @@ public class Config {
         }
         if(DeepConstants.MOD_TCON_LOADED) {
             dataModel.put(MobKey.TINKERSLIME, config.get(dataModel.getName(), MobKey.TINKERSLIME, 256,null, 1, 6666));
+        }
+    }
+
+    private static void initDataModelMobs() {
+        dataModelMobs.setComment("Register entities that count towards leveling up the model\nFormat is modname:entity_name");
+        config.setCategoryComment(dataModelMobs.getName(), dataModelMobs.getComment());
+
+        dataModelMobs.put(MobKey.ZOMBIE, new Property(MobKey.ZOMBIE, config.getStringList(MobKey.ZOMBIE, dataModelMobs.getName(), DeepConstants.MOBS.ZOMBIE, "Zombie"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.SKELETON, new Property(MobKey.SKELETON, config.getStringList(MobKey.SKELETON, dataModelMobs.getName(), DeepConstants.MOBS.SKELETON, "Creeper"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.BLAZE, new Property(MobKey.BLAZE, config.getStringList(MobKey.BLAZE, dataModelMobs.getName(), DeepConstants.MOBS.BLAZE, "BLAZE"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.ENDERMAN, new Property(MobKey.ENDERMAN, config.getStringList(MobKey.ENDERMAN, dataModelMobs.getName(), DeepConstants.MOBS.ENDERMAN, "Enderman"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.WITHER, new Property(MobKey.WITHER, config.getStringList(MobKey.WITHER, dataModelMobs.getName(), DeepConstants.MOBS.WITHER, "Wither"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.WITCH, new Property(MobKey.WITCH, config.getStringList(MobKey.WITCH, dataModelMobs.getName(), DeepConstants.MOBS.WITCH, "Witch"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.SPIDER, new Property(MobKey.SPIDER, config.getStringList(MobKey.SPIDER, dataModelMobs.getName(), DeepConstants.MOBS.SPIDER, "Spider"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.CREEPER, new Property(MobKey.CREEPER, config.getStringList(MobKey.CREEPER, dataModelMobs.getName(), DeepConstants.MOBS.CREEPER, "Creeper"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.GHAST, new Property(MobKey.GHAST, config.getStringList(MobKey.GHAST, dataModelMobs.getName(), DeepConstants.MOBS.GHAST, "Ghast"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.SLIME, new Property(MobKey.SLIME, config.getStringList(MobKey.SLIME, dataModelMobs.getName(), DeepConstants.MOBS.SLIME, "Slime"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.DRAGON, new Property(MobKey.DRAGON, config.getStringList(MobKey.DRAGON, dataModelMobs.getName(), DeepConstants.MOBS.DRAGON, "Dragon"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.SHULKER, new Property(MobKey.SHULKER, config.getStringList(MobKey.SHULKER, dataModelMobs.getName(), DeepConstants.MOBS.SHULKER, "Shulker"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.GUARDIAN, new Property(MobKey.GUARDIAN, config.getStringList(MobKey.GUARDIAN, dataModelMobs.getName(), DeepConstants.MOBS.GUARDIAN, "Guardian"), Property.Type.STRING));
+        dataModelMobs.put(MobKey.WITHERSKELETON, new Property(MobKey.WITHERSKELETON, config.getStringList(MobKey.WITHERSKELETON, dataModelMobs.getName(), DeepConstants.MOBS.WITHERSKELETON, "Wither Skeleton"), Property.Type.STRING));
+
+        /* Extension models */
+        if(DeepConstants.MOD_TE_LOADED) {
+            dataModelMobs.put(MobKey.TE, new Property(MobKey.TE, config.getStringList(MobKey.TE, dataModelMobs.getName(), DeepConstants.MOBS.THERMALELEMENTAL, "Thermal Elemental"), Property.Type.STRING));
+        }
+        if(DeepConstants.MOD_TWILIGHT_LOADED) {
+            dataModelMobs.put(MobKey.TWILIGHTFOREST, new Property(MobKey.TWILIGHTFOREST, config.getStringList(MobKey.TWILIGHTFOREST, dataModelMobs.getName(), DeepConstants.MOBS.TWILIGHTFOREST, "Twilight Forest(Biome, not the whole mod)"), Property.Type.STRING));
+            dataModelMobs.put(MobKey.TWILIGHTSWAMP, new Property(MobKey.TWILIGHTSWAMP, config.getStringList(MobKey.TWILIGHTSWAMP, dataModelMobs.getName(), DeepConstants.MOBS.TWILIGHTSWAMP, "Twilight Swamp creatures"), Property.Type.STRING));
+            dataModelMobs.put(MobKey.TWILIGHTDARKWOOD, new Property(MobKey.TWILIGHTDARKWOOD, config.getStringList(MobKey.TWILIGHTDARKWOOD, dataModelMobs.getName(), DeepConstants.MOBS.TWILIGHTDARKWOOD, "Twilight Darkwood creatures"), Property.Type.STRING));
+            dataModelMobs.put(MobKey.TWILIGHTGLACIER, new Property(MobKey.TWILIGHTGLACIER, config.getStringList(MobKey.TWILIGHTGLACIER, dataModelMobs.getName(), DeepConstants.MOBS.TWILIGHTGLACIER, "Twilight Glacier creatures"), Property.Type.STRING));
+        }
+        if(DeepConstants.MOD_TCON_LOADED) {
+            dataModelMobs.put(MobKey.TINKERSLIME, new Property(MobKey.TINKERSLIME, config.getStringList(MobKey.TINKERSLIME, dataModelMobs.getName(), DeepConstants.MOBS.TINKERSLIME, "Tinker construct slime"), Property.Type.STRING));
         }
     }
 

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/BlazeMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/BlazeMeta.java
@@ -15,11 +15,6 @@ public class BlazeMeta extends MobMetaData {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
     }
 
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityBlaze;
-    }
-
     public EntityBlaze getEntity(World world) {
         return new EntityBlaze(world);
     }

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/CreeperMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/CreeperMeta.java
@@ -1,7 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityCreeper;
 import net.minecraft.item.Item;
 
@@ -13,11 +12,6 @@ public class CreeperMeta extends MobMetaData {
 
     CreeperMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityCreeper;
     }
 
     public EntityCreeper getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/DragonMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/DragonMeta.java
@@ -1,7 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.boss.EntityDragon;
 import net.minecraft.item.Item;
 
@@ -13,11 +12,6 @@ public class DragonMeta extends MobMetaData {
 
     DragonMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityDragon;
     }
 
     public EntityDragon getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/EndermanMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/EndermanMeta.java
@@ -1,7 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityEnderman;
 import net.minecraft.item.Item;
 
@@ -13,11 +12,6 @@ public class EndermanMeta extends MobMetaData {
 
     EndermanMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityEnderman;
     }
 
     public EntityEnderman getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/GhastMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/GhastMeta.java
@@ -1,7 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityGhast;
 import net.minecraft.item.Item;
 
@@ -13,11 +12,6 @@ public class GhastMeta extends MobMetaData {
 
     GhastMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityGhast;
     }
 
     public EntityGhast getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/GuardianMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/GuardianMeta.java
@@ -1,6 +1,5 @@
 package xt9.deepmoblearning.common.mobmetas;
 
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityGuardian;
 import net.minecraft.item.Item;
 import net.minecraft.world.World;
@@ -14,12 +13,6 @@ public class GuardianMeta extends MobMetaData {
     GuardianMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
     }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityGuardian;
-    }
-
 
     @Override
     public EntityGuardian getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/MobMetaData.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/MobMetaData.java
@@ -4,9 +4,13 @@ import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.registry.EntityEntry;
+import net.minecraftforge.fml.common.registry.EntityRegistry;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.commons.lang3.ArrayUtils;
 import xt9.deepmoblearning.DeepConstants;
 import xt9.deepmoblearning.common.config.Config;
 import xt9.deepmoblearning.common.items.ItemLivingMatter;
@@ -27,6 +31,8 @@ public abstract class MobMetaData {
     protected ItemLivingMatter livingMatter;
     protected ItemPristineMatter pristineMatter;
     protected String[] mobTrivia;
+
+    private String[] mobRegistryNames;
 
     public MobMetaData(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter, String[] mobTrivia) {
         this.key = key;
@@ -99,6 +105,18 @@ public abstract class MobMetaData {
     }
 
     public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
+        EntityEntry entry = EntityRegistry.getEntry(entityLiving.getClass());
+        if (entry != null) {
+            ResourceLocation registryName = entry.getRegistryName();
+            if (registryName != null) {
+                String name = registryName.toString();
+                return ArrayUtils.contains(Config.dataModelMobs.get(getKey()).getStringList(), name);
+            }
+
+            // Fallback to the name, but this should never happen
+            return ArrayUtils.contains(Config.dataModelMobs.get(getKey()).getStringList(), entry.getName());
+        }
+
         return false;
     }
 

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/ShulkerMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/ShulkerMeta.java
@@ -1,12 +1,8 @@
 package xt9.deepmoblearning.common.mobmetas;
 
-import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.monster.EntityGhast;
 import net.minecraft.entity.monster.EntityShulker;
 import net.minecraft.item.Item;
 import net.minecraft.world.World;
-import xt9.deepmoblearning.common.items.ItemLivingMatter;
-import xt9.deepmoblearning.common.items.ItemPristineMatter;
 
 /**
  * Created by xt9 on 2018-05-05.
@@ -16,11 +12,6 @@ public class ShulkerMeta extends MobMetaData {
 
     ShulkerMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityShulker;
     }
 
     public EntityShulker getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/SkeletonMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/SkeletonMeta.java
@@ -1,8 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
-import net.minecraft.entity.monster.AbstractSkeleton;
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntitySkeleton;
 import net.minecraft.init.Items;
 import net.minecraft.item.*;
@@ -16,11 +14,6 @@ public class SkeletonMeta extends MobMetaData {
 
     SkeletonMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof AbstractSkeleton;
     }
 
     public EntitySkeleton getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/SlimeMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/SlimeMeta.java
@@ -1,7 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntitySlime;
 import net.minecraft.item.Item;
 
@@ -13,11 +12,6 @@ public class SlimeMeta extends MobMetaData {
 
     SlimeMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntitySlime;
     }
 
     public EntitySlime getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/SpiderMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/SpiderMeta.java
@@ -1,7 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityCaveSpider;
 import net.minecraft.entity.monster.EntitySpider;
 import net.minecraft.item.Item;
@@ -14,11 +13,6 @@ public class SpiderMeta extends MobMetaData {
 
     SpiderMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntitySpider;
     }
 
     public EntitySpider getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/ThermalElementalMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/ThermalElementalMeta.java
@@ -1,10 +1,7 @@
 package xt9.deepmoblearning.common.mobmetas;
 
-import cofh.thermalfoundation.entity.monster.EntityBasalz;
-import cofh.thermalfoundation.entity.monster.EntityBlitz;
 import cofh.thermalfoundation.entity.monster.EntityBlizz;
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
 
 /**
@@ -15,13 +12,6 @@ public class ThermalElementalMeta extends MobMetaData {
 
     ThermalElementalMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityBlitz ||
-            entityLiving instanceof EntityBasalz ||
-            entityLiving instanceof EntityBlizz;
     }
 
     public EntityBlizz getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/TinkerSlimeMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/TinkerSlimeMeta.java
@@ -1,6 +1,5 @@
 package xt9.deepmoblearning.common.mobmetas;
 
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
 import net.minecraft.world.World;
 import slimeknights.tconstruct.world.entity.EntityBlueSlime;
@@ -13,11 +12,6 @@ public class TinkerSlimeMeta extends MobMetaData {
 
     TinkerSlimeMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityBlueSlime;
     }
 
     public EntityBlueSlime getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/TwilightDarkwoodMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/TwilightDarkwoodMeta.java
@@ -1,10 +1,7 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
-import twilightforest.entity.*;
-import twilightforest.entity.boss.EntityTFKnightPhantom;
 import twilightforest.entity.boss.EntityTFUrGhast;
 
 /**
@@ -15,21 +12,6 @@ public class TwilightDarkwoodMeta extends MobMetaData {
 
     TwilightDarkwoodMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityTFRedcap ||
-            entityLiving instanceof EntityTFBlockGoblin ||
-            entityLiving instanceof EntityTFKobold ||
-            entityLiving instanceof EntityTFGoblinKnightLower ||
-            entityLiving instanceof EntityTFGoblinKnightUpper ||
-            entityLiving instanceof EntityTFHelmetCrab ||
-            entityLiving instanceof EntityTFKnightPhantom ||
-            entityLiving instanceof EntityTFTowerGhast ||
-            entityLiving instanceof EntityTFTowerBroodling ||
-            entityLiving instanceof EntityTFTowerGolem ||
-            entityLiving instanceof EntityTFTowerTermite;
     }
 
     public EntityTFUrGhast getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/TwilightForestMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/TwilightForestMeta.java
@@ -1,13 +1,8 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.item.Item;
-import twilightforest.entity.EntityTFDeathTome;
-import twilightforest.entity.EntityTFSwarmSpider;
 import twilightforest.entity.boss.EntityTFLich;
-import twilightforest.entity.boss.EntityTFLichMinion;
-import twilightforest.entity.boss.EntityTFNaga;
 
 /**
  * Created by xt9 on 2018-01-18.
@@ -17,15 +12,6 @@ public class TwilightForestMeta extends MobMetaData {
 
     TwilightForestMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityTFNaga ||
-            entityLiving instanceof EntityTFLichMinion ||
-            entityLiving instanceof EntityTFLich ||
-            entityLiving instanceof EntityTFDeathTome ||
-            entityLiving instanceof EntityTFSwarmSpider;
     }
 
     public EntityTFLich getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/TwilightGlacierMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/TwilightGlacierMeta.java
@@ -1,15 +1,11 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHand;
-import twilightforest.entity.*;
 import twilightforest.entity.boss.EntityTFSnowQueen;
-import twilightforest.entity.boss.EntityTFYetiAlpha;
-import twilightforest.entity.passive.EntityTFPenguin;
 
 /**
  * Created by xt9 on 2018-01-21.
@@ -19,18 +15,6 @@ public class TwilightGlacierMeta extends MobMetaData {
 
     TwilightGlacierMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityTFYetiAlpha ||
-            entityLiving instanceof EntityTFYeti ||
-            entityLiving instanceof EntityTFWinterWolf ||
-            entityLiving instanceof EntityTFPenguin ||
-            entityLiving instanceof EntityTFSnowGuardian ||
-            entityLiving instanceof EntityTFIceShooter ||
-            entityLiving instanceof EntityTFIceExploder ||
-            entityLiving instanceof EntityTFSnowQueen;
     }
 
     public EntityTFSnowQueen getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/TwilightSwampMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/TwilightSwampMeta.java
@@ -1,13 +1,10 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumHand;
-import twilightforest.entity.*;
-import twilightforest.entity.boss.EntityTFHydra;
 import twilightforest.entity.boss.EntityTFMinoshroom;
 
 
@@ -19,16 +16,6 @@ public class TwilightSwampMeta extends MobMetaData {
 
     TwilightSwampMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityTFMinotaur ||
-            entityLiving instanceof EntityTFMazeSlime ||
-            entityLiving instanceof EntityTFFireBeetle ||
-            entityLiving instanceof EntityTFPinchBeetle ||
-            entityLiving instanceof EntityTFSlimeBeetle ||
-            entityLiving instanceof EntityTFHydra;
     }
 
     public EntityTFMinoshroom getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/WitchMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/WitchMeta.java
@@ -1,7 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityWitch;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
@@ -16,11 +15,6 @@ public class WitchMeta extends MobMetaData {
 
     WitchMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityWitch;
     }
 
     public EntityWitch getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/WitherMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/WitherMeta.java
@@ -1,7 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.boss.EntityWither;
 import net.minecraft.item.Item;
 
@@ -13,11 +12,6 @@ public class WitherMeta extends MobMetaData {
 
     WitherMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityWither;
     }
 
     public EntityWither getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/WitherSkeletonMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/WitherSkeletonMeta.java
@@ -1,7 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityWitherSkeleton;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
@@ -16,11 +15,6 @@ public class WitherSkeletonMeta extends MobMetaData {
 
     WitherSkeletonMeta(String key, String name, String pluralName, int numberOfHearts, int interfaceScale, int interfaceOffsetX, int interfaceOffsetY, Item livingMatter, Item pristineMatter) {
         super(key, name, pluralName, numberOfHearts, interfaceScale, interfaceOffsetX, interfaceOffsetY, livingMatter, pristineMatter, mobTrivia);
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityWitherSkeleton;
     }
 
     public EntityWitherSkeleton getEntity(World world) {

--- a/src/main/java/xt9/deepmoblearning/common/mobmetas/ZombieMeta.java
+++ b/src/main/java/xt9/deepmoblearning/common/mobmetas/ZombieMeta.java
@@ -1,7 +1,6 @@
 package xt9.deepmoblearning.common.mobmetas;
 
 import net.minecraft.world.World;
-import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.item.Item;
 
@@ -24,11 +23,6 @@ public class ZombieMeta extends MobMetaData {
         childEntity.setChild(true);
 
         return childEntity;
-    }
-
-    @Override
-    public boolean entityLivingMatchesMob(EntityLivingBase entityLiving) {
-        return entityLiving instanceof EntityZombie;
     }
 
     public int getExtraInterfaceOffsetX() {


### PR DESCRIPTION
First off, I really enjoy your mod. However with the current way of counting mob kills for the data models through instanceof checks there are certain side effects. E.g. a wither skeleton is also inheriting from AbstractSkeleton and therefore also counts towards the skeleton data model. The same "problem" happens for leveling up the vanilla slime data model through Tinkers blue slime.

For this reason I implemented this PR that uses the entity registry names of the entities that count towards a data model instead of class inheritance. Also these values are taken from the config file, so a modpack maker can tweak the mob classes which would make integrating with other mods possible without changing the code or depending on their class hierarchy.
