### PR TITLE
Fix dupe with containers

### DIFF
--- a/src/main/java/xt9/deepmoblearning/common/inventory/ContainerExtractionChamber.java
+++ b/src/main/java/xt9/deepmoblearning/common/inventory/ContainerExtractionChamber.java
@@ -10,6 +10,7 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import xt9.deepmoblearning.DeepConstants;
 import xt9.deepmoblearning.common.tiles.TileEntityExtractionChamber;
+import net.minecraft.util.math.BlockPos;
 
 /**
  * Created by xt9 on 2018-01-07.
@@ -144,7 +145,12 @@ public class ContainerExtractionChamber extends Container {
     }
 
     @Override
-    public boolean canInteractWith(EntityPlayer player) {
-        return !player.isSpectator();
-    }
+	public boolean canInteractWith(EntityPlayer player) {
+		BlockPos pos = this.tile.getPos();
+		if (this.tile.getWorld().getTileEntity(pos) != this.tile) {
+			return false;
+		} else {
+			return player.getDistanceSq(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D) <= 64.0D;
+		}
+	}
 }

--- a/src/main/java/xt9/deepmoblearning/common/inventory/ContainerSimulationChamber.java
+++ b/src/main/java/xt9/deepmoblearning/common/inventory/ContainerSimulationChamber.java
@@ -11,6 +11,7 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import xt9.deepmoblearning.DeepConstants;
 import xt9.deepmoblearning.common.tiles.TileEntitySimulationChamber;
+import net.minecraft.util.math.BlockPos;
 
 /**
  * Created by xt9 on 2017-06-17.
@@ -112,7 +113,12 @@ public class ContainerSimulationChamber extends Container {
     }
 
     @Override
-    public boolean canInteractWith(EntityPlayer entityplayer) {
-        return !entityplayer.isSpectator();
-    }
+	public boolean canInteractWith(EntityPlayer player) {
+		BlockPos pos = this.tile.getPos();
+		if (this.tile.getWorld().getTileEntity(pos) != this.tile) {
+			return false;
+		} else {
+			return player.getDistanceSq(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D) <= 64.0D;
+		}
+	}
 }

--- a/src/main/java/xt9/deepmoblearning/common/inventory/ContainerTrialKeystone.java
+++ b/src/main/java/xt9/deepmoblearning/common/inventory/ContainerTrialKeystone.java
@@ -9,6 +9,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.items.IItemHandler;
 import xt9.deepmoblearning.DeepConstants;
 import xt9.deepmoblearning.common.tiles.TileEntityTrialKeystone;
+import net.minecraft.util.math.BlockPos;
 
 /**
  * Created by xt9 on 2018-03-25.
@@ -97,7 +98,12 @@ public class ContainerTrialKeystone extends Container {
     }
 
     @Override
-    public boolean canInteractWith(EntityPlayer player) {
-        return !player.isSpectator();
-    }
+	public boolean canInteractWith(EntityPlayer player) {
+		BlockPos pos = this.tile.getPos();
+		if (this.tile.getWorld().getTileEntity(pos) != this.tile) {
+			return false;
+		} else {
+			return player.getDistanceSq(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D) <= 64.0D;
+		}
+	}
 }


### PR DESCRIPTION
This fixes a dupes with containers.
Open the tile container, the second player breaks the tile, the gui does not close = dupe items.

The code also checks how far the player is, this also corrects the error if you open the crater container and leave on a trolley from it.