### PR TITLE
Make pachouli book name can be translated

### DIFF
--- a/src/main/resources/assets/deepmoblearning/lang/en_us.lang
+++ b/src/main/resources/assets/deepmoblearning/lang/en_us.lang
@@ -10,6 +10,9 @@ tile.deepmoblearning.infused_ingot_block.name=Glitch Infused Block
 # Single items
 #
 item.deepmoblearning.book.name=Placeholder Guide (Install Patchouli)
+item.deepmoblearning.guide_book.name=Deep Mob Learning
+item.deepmoblearning.guide_book.subtitle=A comprehensive Guide
+item.deepmoblearning.guide_book.desc=$(dml) adds new ways to acquire loot that normally drops from mobs, the intent is to remove the need for a big laggy mobfarm.$(br2)The mod is inspired by $(l:https://minecraft.curseforge.com/projects/soul-shards-respawn)Soul shards$() and $(l:https://minecraft.curseforge.com/projects/woot)Woot$().$(br2)This guide was written with $(l:https://minecraft.curseforge.com/projects/patchouli)Patchouli$(), a $(o)neat$() mod by $(l:https://twitter.com/Vazkii)Vazkii$().
 item.deepmoblearning.polymer_clay.name=Polymer Clay
 item.deepmoblearning.soot_covered_redstone.name=Soot-covered Redstone
 item.deepmoblearning.soot_covered_plate.name=Soot-covered Plate

--- a/src/main/resources/assets/deepmoblearning/patchouli_books/book/book.json
+++ b/src/main/resources/assets/deepmoblearning/patchouli_books/book/book.json
@@ -1,6 +1,6 @@
 {
-    "name": "Deep Mob Learning",
-    "subtitle": "A comprehensive Guide",
+    "name": "item.deepmoblearning.guide_book.name",
+    "subtitle": "item.deepmoblearning.guide_book.subtitle",
     "creative_tab": "deepmoblearning",
     "book_texture": "deepmoblearning:textures/gui/patchouli/book_gray.png",
     "crafting_texture": "deepmoblearning:textures/gui/patchouli/crafting.png",
@@ -11,7 +11,7 @@
     "link_hover_color": "00FFC0",
     "show_progress": false,
     "model": "deepmoblearning:book",
-    "landing_text": "$(dml) adds new ways to acquire loot that normally drops from mobs, the intent is to remove the need for a big laggy mobfarm.$(br2)The mod is inspired by $(l:https://minecraft.curseforge.com/projects/soul-shards-respawn)Soul shards$() and $(l:https://minecraft.curseforge.com/projects/woot)Woot$().$(br2)This guide was written with $(l:https://minecraft.curseforge.com/projects/patchouli)Patchouli$(), a $(o)neat$() mod by $(l:https://twitter.com/Vazkii)Vazkii$().",
+    "landing_text": "item.deepmoblearning.guide_book.desc",
     "macros": {
         "$(primary)": "$(#16EFF7)",
         "$(item)": "$(#ff8c00)",


### PR DESCRIPTION
The name, subtitle, and landing text of the pachouli book can't be translated, so I added them in this PR as .lang keys.