### PR TITLE
Resolves issue causing edge case crash

### DIFF
--- a/src/main/java/xt9/deepmoblearning/common/events/EntityDeathHandler.java
+++ b/src/main/java/xt9/deepmoblearning/common/events/EntityDeathHandler.java
@@ -113,8 +113,11 @@ public class EntityDeathHandler {
     }
 
     private static void cullEntityBlacklist() {
+        if (killedEntityUUIDBlacklist.isEmpty()) return;
+    
         UUID lastUUID = killedEntityUUIDBlacklist.get(killedEntityUUIDBlacklist.size() - 1);
-        killedEntityUUIDBlacklist.clear();
+    
+        killedEntityUUIDBlacklist = new ArrayList<>();
         killedEntityUUIDBlacklist.add(lastUUID);
     }
 

--- a/src/main/java/xt9/deepmoblearning/common/events/EntityDeathHandler.java
+++ b/src/main/java/xt9/deepmoblearning/common/events/EntityDeathHandler.java
@@ -203,7 +203,7 @@ public class EntityDeathHandler {
     }
 
     private static boolean isEntityBlacklisted(EntityLivingBase entityLiving) {
-        return killedEntityUUIDBlacklist.stream().filter(uuid -> uuid.toString().equals(entityLiving.getUniqueID().toString())).collect(Collectors.toList()).size() > 0;
+        return killedEntityUUIDBlacklist.contains(entityLiving.getUniqueID());
     }
 
     private static void attuneTrialKey(ItemStack trialKey, ItemStack dataModel, LivingDeathEvent event, EntityPlayerMP player) {

--- a/src/main/java/xt9/deepmoblearning/common/events/EntityDeathHandler.java
+++ b/src/main/java/xt9/deepmoblearning/common/events/EntityDeathHandler.java
@@ -117,7 +117,7 @@ public class EntityDeathHandler {
     
         UUID lastUUID = killedEntityUUIDBlacklist.get(killedEntityUUIDBlacklist.size() - 1);
     
-        killedEntityUUIDBlacklist = new ArrayList<>();
+        killedEntityUUIDBlacklist = NonNullList.create();
         killedEntityUUIDBlacklist.add(lastUUID);
     }
 


### PR DESCRIPTION
Fixes a crash caused by unsafe modification of killedEntityUUIDBlacklist in EntityDeathHandler, which could result in a NoSuchElementException during mob death events.

Root Cause
- isEntityBlacklisted() iterates over killedEntityUUIDBlacklist using a stream (creating an iterator).
- At the same time, cullEntityBlacklist() calls clear() on the same list.
- When multiple LivingDeathEvents fire in quick succession (e.g., automated mob killing), this leads to modification of the list while it is being iterated.
- This violates iterator safety and causes a crash: `java.util.NoSuchElementException
at java.util.AbstractList$Itr.next`

Changes

Replaced stream-based lookup in isEntityBlacklisted() with a direct .contains() check:
- Avoids unnecessary iteration and allocation
- Improves performance and readability

Updated cullEntityBlacklist() to avoid unsafe in-place mutation:
- Replaces the list instead of clearing it while it may be in use

Issue is reproducible with rapidly killing mobs through automated means.

Test: ran high rate mob grinder (using mob-grinding-utils, roost, extra utilities) resulting in a mob kill every 1-3 ticks. Before fix, the game would crash every 1-3 hours. After fix, I've gone now well over 12 hours with no crash.